### PR TITLE
Reactnative markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "16.3.1",
     "react-native": "~0.55.2",
     "react-native-elements": "^0.19.1",
+    "react-native-markdown-renderer": "^3.2.8",
     "react-native-parallax-scroll-view": "^0.21.3",
     "react-navigation": "^2.8.0"
   },

--- a/src/components/MarkDown.js
+++ b/src/components/MarkDown.js
@@ -1,0 +1,41 @@
+// @flow
+
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import Markdown, {styles} from 'react-native-markdown-renderer';
+type Props = {
+  content: string;
+};
+function markDown(props: Props) {
+  let {content} = props;
+  return <Markdown style={styles}>{content}</Markdown>;
+}
+
+export default markDown;
+
+const syles = StyleSheet.create({
+  heading: {
+    borderBottomWidth: 1,
+    borderColor: '#000000',
+  },
+  heading1: {
+    fontSize: 32,
+    backgroundColor: '#000000',
+    color: '#FFFFFF',
+  },
+  heading2: {
+    fontSize: 24,
+  },
+  heading3: {
+    fontSize: 18,
+  },
+  heading4: {
+    fontSize: 16,
+  },
+  heading5: {
+    fontSize: 13,
+  },
+  heading6: {
+    fontSize: 11,
+  },
+});


### PR DESCRIPTION
- add react-native-markdown-renderer as dependencies
- create markdown component

```
type Props = {
  content: string;
};
function markDown(props: Props) {
  let {content} = props;
  return <Markdown style={styles}>{content}</Markdown>;
}

```
<img width="358" alt="screen shot 2018-08-08 at 13 58 39" src="https://user-images.githubusercontent.com/20268062/43821413-514e2e26-9b13-11e8-9e77-6414ffa9a14f.png">
