### PR TITLE
Event Screen

### DIFF
--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -1,0 +1,108 @@
+// @flow
+import React from 'react';
+import {View, Text, Image, StyleSheet} from 'react-native';
+import {RowWith3Column, Icon} from '../general/core-ui/index';
+import {EventContent} from './index';
+
+type Event = {
+  profilePicture: string,
+  username: string,
+  action: 'COMMENT_PR' | 'COMMENT_ISSUE' | 'PR' | 'ISSUE' | 'FORK',
+  actionTarget: string,
+  repoTarget: string,
+  date: string,
+  comment?: string,
+};
+
+type EventCardProps = {
+  event: Event,
+  openRepo: (repo: string) => void,
+  openUser: (user: string) => void,
+};
+
+function EventCard(props: EventCardProps) {
+  let {event, openRepo, openUser} = props;
+  let {profilePicture, action, comment} = event;
+  const {cardContainer, textComment} = styles;
+  return (
+    <View style={cardContainer}>
+      <RowWith3Column
+        left={
+          <Image
+            style={{width: 32, height: 32, borderRadius: 16}}
+            source={{uri: profilePicture}}
+          />
+        }
+        content={
+          <EventContent event={event} openRepo={openRepo} openUser={openUser} />
+        }
+        right={renderIconAction(action)}
+      />
+      {comment ? (
+        <Text style={textComment} numberOfLines={3}>
+          {comment}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function renderIconAction(action: string) {
+  switch (action) {
+    case 'COMMENT_PR':
+      return (
+        <Icon
+          name="comment-discussion"
+          size={24}
+          color="grey"
+          type="OCTICONS"
+        />
+      );
+    case 'COMMENT_ISSUE':
+      return (
+        <Icon
+          name="comment-discussion"
+          size={24}
+          color="grey"
+          type="OCTICONS"
+        />
+      );
+    case 'PR':
+      return (
+        <Icon name="git-pull-request" size={24} color="grey" type="OCTICONS" />
+      );
+    case 'ISSUE':
+      return (
+        <Icon name="issue-opened" size={24} color="grey" type="OCTICONS" />
+      );
+    case 'FORK':
+      return <Icon name="repo-forked" size={24} color="grey" type="OCTICONS" />;
+    default:
+      return null;
+  }
+}
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    borderWidth: 0.5,
+    borderColor: '#d6d4d4',
+    backgroundColor: '#fff',
+  },
+  textComment: {
+    color: 'grey',
+    fontWeight: 'bold',
+    paddingTop: 0,
+    padding: 12,
+  },
+  contentCcontainer: {
+    padding: 6,
+  },
+  textBold: {
+    fontWeight: 'bold',
+  },
+  textDate: {
+    color: 'grey',
+  },
+});
+
+export default EventCard;

--- a/src/components/EventContent.js
+++ b/src/components/EventContent.js
@@ -1,0 +1,70 @@
+//@flow
+import React from 'react';
+import {Text, StyleSheet} from 'react-native';
+
+type Event = {
+  profilePicture: string,
+  username: string,
+  action: 'COMMENT_PR' | 'COMMENT_ISSUE' | 'PR' | 'ISSUE' | 'FORK',
+  actionTarget: string,
+  repoTarget: string,
+  date: string,
+  comment?: string,
+};
+
+type EventContentProps = {
+  event: Event,
+  openRepo: (repo: string) => void,
+  openUser: (user: string) => void,
+};
+
+function EventContent(props: EventContentProps) {
+  let {event, openRepo, openUser} = props;
+  let {username, action, actionTarget, repoTarget, date} = event;
+  const {contentContainer, textBold, textDate} = styles;
+  let description = '';
+  switch (action) {
+    case 'COMMENT_PR':
+      description = 'commented on pull request';
+      break;
+    case 'COMMENT_ISSUE':
+      description = 'commented on issue';
+      break;
+    case 'PR':
+      description = 'opened pull request';
+      break;
+    case 'ISSUE':
+      description = 'opened issue';
+      break;
+    case 'FORK':
+      description = 'forked';
+      break;
+  }
+  return (
+    <Text>
+      <Text style={textBold} onPress={openUser}>
+        {username}{' '}
+      </Text>
+      {description}
+      <Text style={textBold} onPress={openRepo}>
+        {' '}{actionTarget}{' '}
+      </Text>
+      at
+      <Text style={textBold} onPress={openRepo}>
+        {' '}{repoTarget}{' '}
+      </Text>
+      <Text style={textDate}>{date}</Text>
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  textBold: {
+    fontWeight: 'bold',
+  },
+  textDate: {
+    color: 'grey',
+  },
+});
+
+export default EventContent;

--- a/src/components/__tests__/EventCard.test.js
+++ b/src/components/__tests__/EventCard.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {EventCard} from '../index';
+
+describe('Icon', () => {
+  it('should render EventCard corectly', () => {
+    let event = {
+      profilePicture:
+        'http://www.grosse.is-a-geek.com/robopics/roborovski01_1024.jpg',
+      username: 'zzzcielo',
+      action: 'COMMENT_ISSUE',
+      actionTarget: 'Parallax Header Bug',
+      repoTarget: 'astridtamara/bootcamp',
+      date: '1d',
+      comment:
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time. ',
+    };
+    let component = renderer.create(
+      <EventCard event={event} openRepo={() => {}} openUser={() => {}} />,
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/EventContent.test.js
+++ b/src/components/__tests__/EventContent.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import {EventContent} from '../index';
+
+describe('Icon', () => {
+  it('should render EventContent corectly', () => {
+    let event = {
+      profilePicture:
+        'http://www.grosse.is-a-geek.com/robopics/roborovski01_1024.jpg',
+      username: 'zzzcielo',
+      action: 'COMMENT_ISSUE',
+      actionTarget: 'Parallax Header Bug',
+      repoTarget: 'astridtamara/bootcamp',
+      date: '1d',
+      comment:
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+        '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time. ',
+    };
+    let component = renderer.create(
+      <EventContent event={event} openRepo={() => {}} openUser={() => {}} />,
+    );
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/__snapshots__/EventCard.test.js.snap
+++ b/src/components/__tests__/__snapshots__/EventCard.test.js.snap
@@ -1,0 +1,185 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Icon should render EventCard corectly 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#fff",
+      "borderColor": "#d6d4d4",
+      "borderWidth": 0.5,
+    }
+  }
+>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    collapsable={undefined}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          },
+          Array [],
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "justifyContent": "center",
+            "width": "15%",
+          }
+        }
+      >
+        <Image
+          source={
+            Object {
+              "uri": "http://www.grosse.is-a-geek.com/robopics/roborovski01_1024.jpg",
+            }
+          }
+          style={
+            Object {
+              "borderRadius": 16,
+              "height": 32,
+              "width": 32,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "flex-start",
+            "flexWrap": "wrap",
+            "justifyContent": "center",
+            "padding": 10,
+            "width": "70%",
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            onPress={[Function]}
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            zzzcielo
+             
+          </Text>
+          commented on issue
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            onPress={[Function]}
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+             
+            Parallax Header Bug
+             
+          </Text>
+          at
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            onPress={[Function]}
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+             
+            astridtamara/bootcamp
+             
+          </Text>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "color": "grey",
+              }
+            }
+          >
+            1d
+          </Text>
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "justifyContent": "center",
+            "width": "15%",
+          }
+        }
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        />
+      </View>
+    </View>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    numberOfLines={3}
+    style={
+      Object {
+        "color": "grey",
+        "fontWeight": "bold",
+        "padding": 12,
+        "paddingTop": 0,
+      }
+    }
+  >
+    [Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time. 
+  </Text>
+</View>
+`;

--- a/src/components/__tests__/__snapshots__/EventContent.test.js.snap
+++ b/src/components/__tests__/__snapshots__/EventContent.test.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Icon should render EventContent corectly 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    onPress={[Function]}
+    style={
+      Object {
+        "fontWeight": "bold",
+      }
+    }
+  >
+    zzzcielo
+     
+  </Text>
+  commented on issue
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    onPress={[Function]}
+    style={
+      Object {
+        "fontWeight": "bold",
+      }
+    }
+  >
+     
+    Parallax Header Bug
+     
+  </Text>
+  at
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    onPress={[Function]}
+    style={
+      Object {
+        "fontWeight": "bold",
+      }
+    }
+  >
+     
+    astridtamara/bootcamp
+     
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "grey",
+      }
+    }
+  >
+    1d
+  </Text>
+</Text>
+`;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,4 @@
 export {default as Repo} from './Repo';
 export {default as Markdown} from './MarkDown';
+export {default as EventCard} from './EventCard';
+export {default as EventContent} from './EventContent';

--- a/src/features/events/screens/EventsScreen.js
+++ b/src/features/events/screens/EventsScreen.js
@@ -2,15 +2,102 @@
 
 import React, {Component} from 'react';
 import {View, Text} from 'react-native';
+import {EventCard} from '../../../components/index';
 
-class EventsScreen extends Component<{}> {
+import type {NavigationScreenProp} from 'react-navigation';
+
+type Event = {
+  profilePicture: string,
+  username: string,
+  action: 'COMMENT_PR' | 'COMMENT_ISSUE' | 'PR' | 'ISSUE' | 'FORK',
+  actionTarget: string,
+  repoTarget: string,
+  date: string,
+  comment?: string,
+};
+
+type Object = {
+  navigation: NavigationScreenProp<[]>,
+};
+
+class EventsScreen extends Component<Object> {
   render() {
+    let eventList: Array<Event> = [
+      {
+        profilePicture:
+          'http://www.grosse.is-a-geek.com/robopics/roborovski01_1024.jpg',
+        username: 'zzzcielo',
+        action: 'COMMENT_ISSUE',
+        actionTarget: 'Parallax Header Bug',
+        repoTarget: 'astridtamara/bootcamp',
+        date: '1d',
+        comment:
+          '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+          '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+          '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time.' +
+          '[Test Long Comment] The bug is bugging me a lot. Good job fixing it in such short time. ',
+      },
+      {
+        profilePicture:
+          'https://d2kwjcq8j5htsz.cloudfront.net/2016/08/16153058/hamster-health-center-2.jpg',
+        username: 'astridtamara',
+        action: 'ISSUE',
+        actionTarget: 'kodefox/kfstart',
+        repoTarget: 'astridtamara/bootcamp',
+        date: '2d',
+      },
+      {
+        profilePicture:
+          'http://www.grosse.is-a-geek.com/robopics/roborovski01_1024.jpg',
+        username: 'zzzcielo',
+        action: 'COMMENT_PR',
+        actionTarget: 'Quick bug fix',
+        repoTarget: 'astridtamara/bootcamp',
+        date: '4d',
+        comment:
+          'The bug is bugging me a lot. Good job fixing it in such short time. ',
+      },
+      {
+        profilePicture:
+          'https://d2kwjcq8j5htsz.cloudfront.net/2016/08/16153058/hamster-health-center-2.jpg',
+        username: 'astridtamara',
+        action: 'PR',
+        actionTarget: 'kodefox/kfstart',
+        repoTarget: 'astridtamara/bootcamp',
+        date: '6d',
+      },
+      {
+        profilePicture:
+          'https://d2kwjcq8j5htsz.cloudfront.net/2016/08/16153058/hamster-health-center-2.jpg',
+        username: 'astridtamara',
+        action: 'FORK',
+        actionTarget: 'kodefox/kfstart',
+        repoTarget: 'astridtamara/bootcamp',
+        date: '6d',
+      },
+    ];
     return (
       <View>
-        <Text>EventsScreen</Text>
+        {eventList.map((event, index) => {
+          return (
+            <EventCard
+              key={index}
+              event={event}
+              openRepo={() => this._openRepo(event.repoTarget)}
+              openUser={() => this._openUser(event.username)}
+            />
+          );
+        })}
       </View>
     );
   }
+
+  _openRepo = (repo: string) => {
+    this.props.navigation.navigate('RepositoryDetailScreen');
+  };
+  _openUser = (user: string) => {
+    this.props.navigation.navigate('UserScreen');
+  };
 }
 
 export default EventsScreen;


### PR DESCRIPTION
**1. Create Component EventContent**
<img width="230" alt="eventcontent" src="https://user-images.githubusercontent.com/28957546/43950011-5bff9560-9cb9-11e8-8515-68fb8dfa6ccd.png">
Event Content is the middle part (consists of text) in an EventCard.

```
type Event = {
  profilePicture: string,
  username: string,
  action: 'COMMENT_PR' | 'COMMENT_ISSUE' | 'PR' | 'ISSUE' | 'FORK',
  actionTarget: string,
  repoTarget: string,
  date: string,
  comment?: string,
};

type EventContentProps = {
  event: Event,
  openRepo: (repo: string) => void,
  openUser: (user: string) => void,
};
```
Event Content receives 3 props.
openRepo and openUser are functions which navigate to the respective screen, the argument received is still temporary.

```
switch (action) {
    case 'COMMENT_PR':
      description = 'commented on pull request';
      break;
    case 'COMMENT_ISSUE':
      description = 'commented on issue';
      break;
    case 'PR':
      description = 'opened pull request';
      break;
    case 'ISSUE':
      description = 'opened issue';
      break;
    case 'FORK':
      description = 'forked';
      break;
  }
```
The text description changes depending on the action provided.

Usage:
```
<EventContent event={event} openRepo={()=>{}} openUser={()=>{}} />
```

**2. Create Component EventCard**
<img width="327" alt="eventcard" src="https://user-images.githubusercontent.com/28957546/43950132-b3d21006-9cb9-11e8-997c-bc2b9249ac6c.png">
<img width="327" alt="eventcard-comment" src="https://user-images.githubusercontent.com/28957546/43950130-b3a1cfcc-9cb9-11e8-8c25-3c3f50aa252e.png">
Event Card uses RowWith3Column with left={Image}, content={EventContent}, right={Icon}.
The Bottom part is the optional comment (which only be shown if the action is 'COMMENT_PR' or 'COMMENT_ISSUE').

```
type Event = {
  profilePicture: string,
  username: string,
  action: 'COMMENT_PR' | 'COMMENT_ISSUE' | 'PR' | 'ISSUE' | 'FORK',
  actionTarget: string,
  repoTarget: string,
  date: string,
  comment?: string,
};

type EventContentProps = {
  event: Event,
  openRepo: (repo: string) => void,
  openUser: (user: string) => void,
};
```
The 'action' determines which Icon to be displayed. Still cannot cover all possible actions because my Event Screen only has 1 entry (on original GitPoint), thus I only add actions listed on GitPoint GitHub.
openRepo and openUser are functions which navigate to the respective screen, the argument received is still temporary. 

Usage:
```
<EventCard event={event} openRepo={() => {}} openUser={() => {}} />
```

**3. Create Test for Component EventContent and EventCard**
The tests pass succesfully.
Updated the App snapshot on the process.

**4. Create Event Screen**
<img width="330" alt="eventscreen" src="https://user-images.githubusercontent.com/28957546/43950509-a657a61a-9cba-11e8-9962-cea98b558ff1.png">
Event Screen uses component EventCard to display the data. Update the routes.js on process, but the navigation still kinda weird (header and such)?
