### PR TITLE
Star list and details without saga

### DIFF
--- a/src/features/profile/screens/ProfileScreen.js
+++ b/src/features/profile/screens/ProfileScreen.js
@@ -94,9 +94,7 @@ class ProfileScreen extends Component<Props, State> {
                 <ParallaxButtons
                   name="Stars"
                   value={this.props.profileState.sumStars}
-                  onPress={() =>
-                    this.props.navigation.navigate('RepositoryScreen')
-                  }
+                  onPress={() => this.props.navigation.navigate('Stars')}
                 />
                 <ParallaxButtons
                   name="Followers"

--- a/src/features/repository/actions/repositoryReducer.action.js
+++ b/src/features/repository/actions/repositoryReducer.action.js
@@ -1,0 +1,14 @@
+// @flow
+
+export type RepositoryAction =
+  | {
+      type: 'REPOSITORY_SUCCESS';
+      payload: Array<*>;
+    }
+  | {
+      type: 'ON_PAGE_MOUNT';
+    }
+  | {
+      type: 'ON_PAGE_MOUNT_ERROR';
+      payload: {message: string};
+    };

--- a/src/features/repository/reducers/repositoryReducer.js
+++ b/src/features/repository/reducers/repositoryReducer.js
@@ -1,0 +1,63 @@
+// @flow
+
+import type {RepositoryAction} from '../actions/repositoryReducer.action';
+
+export type Items = {
+  id: number;
+  name: string;
+  description: string;
+  stargazersCount: number;
+  forked: number;
+  language: string;
+  repoType: string;
+  link: string;
+};
+
+export type RepositoryState = {
+  repositoryList?: Array<Items>;
+};
+
+export const initialState: RepositoryState = {
+  repositoryList: [],
+};
+
+function repositoryReducer(
+  state: RepositoryState = initialState,
+  action: RepositoryAction,
+) {
+  switch (action.type) {
+    case 'REPOSITORY_SUCCESS':
+      let repoData: Array<Items> = [];
+      for (let i = 0; i < action.payload.length; i++) {
+        let repoType: string;
+        if (action.payload[i].fork === false) {
+          repoType = 'repo-forked';
+        } else {
+          repoType = 'repo';
+        }
+        let breakData: Items = {
+          id: action.payload[i].id,
+          name: action.payload[i].name,
+          description: action.payload[i].description,
+          stargazersCount: action.payload[i].stargazers_count,
+          forked: action.payload[i].forks_count,
+          language: action.payload[i].language,
+          link: action.payload[i].url,
+          repoType: repoType,
+        };
+        repoData.push(breakData);
+      }
+      return {
+        ...state,
+        repositoryList: repoData,
+      };
+    case 'ON_PAGE_MOUNT':
+      return state;
+    case 'ON_PAGE_MOUNT_ERROR':
+      return {...state, message: action.payload.message};
+    default:
+      return state;
+  }
+}
+
+export default repositoryReducer;

--- a/src/features/repository/sagas/repositorySaga.js
+++ b/src/features/repository/sagas/repositorySaga.js
@@ -1,0 +1,33 @@
+import {put, all, fork, takeLatest, call} from 'redux-saga/effects';
+import fetchJSON from '../../../global/helpers/fetchJSON';
+
+//watcher
+export default function* onPageInit() {
+  yield takeLatest('ON_PAGE_MOUNT', fetchDataForPage);
+}
+
+//saga
+export function* fetchDataForPage() {
+  try {
+    yield all([
+      fork(requestAndPut, [repositoryRequest], repositoryRequestActionCreator),
+    ]);
+  } catch (e) {
+    yield put({type: 'ON_PAGE_MOUNT_ERROR', payload: {message: e}});
+  }
+}
+
+//helper
+function* requestAndPut(requestParameters, actionCreator) {
+  const result = yield call(...requestParameters);
+  yield put(actionCreator(result));
+}
+
+const repositoryRequest = () => {
+  return fetchJSON('user/repos', 'GET');
+};
+
+const repositoryRequestActionCreator = (data) => ({
+  type: 'REPOSITORY_SUCCESS',
+  payload: data,
+});

--- a/src/features/star/actions/starReducer.action.js
+++ b/src/features/star/actions/starReducer.action.js
@@ -1,0 +1,14 @@
+// @flow
+
+export type RepositoryAction =
+  | {
+      type: 'STARRED_REPOSITORY_SUCCESS';
+      payload: Array<*>;
+    }
+  | {
+      type: 'ON_PAGE_MOUNT';
+    }
+  | {
+      type: 'ON_PAGE_MOUNT_ERROR';
+      payload: {message: string};
+    };

--- a/src/features/star/reducers/starListReducer.js
+++ b/src/features/star/reducers/starListReducer.js
@@ -1,0 +1,30 @@
+// @flow
+import type {RepoFromAPI} from '../types';
+type RepositoryListAction = {
+  type: 'STARRED_REPOSITORY_SUCCESS';
+  payload: {uri: string; data: Array<RepoFromAPI>};
+};
+type InitialState = {
+  lastUri?: string;
+  lastResult?: Array<RepoFromAPI>;
+};
+
+let initialState: InitialState = {};
+
+async function repositoryListReducer(
+  state: InitialState = initialState,
+  action: RepositoryListAction,
+) {
+  switch (action.type) {
+    case 'STARRED_REPOSITORY_SUCCESS':
+      return {
+        ...state,
+        lastUri: action.payload.uri,
+        lastResult: action.payload.data,
+      };
+    default:
+      return state;
+  }
+}
+
+export default repositoryListReducer;

--- a/src/features/star/reducers/starReducer.js
+++ b/src/features/star/reducers/starReducer.js
@@ -1,0 +1,63 @@
+// @flow
+
+import type {RepositoryAction} from '../actions/starReducer.action';
+
+export type Items = {
+  id: number;
+  name: string;
+  description: string;
+  stargazersCount: number;
+  forked: number;
+  language: string;
+  repoType: string;
+  link: string;
+};
+
+export type RepositoryState = {
+  repositoryList?: Array<Items>;
+};
+
+export const initialState: RepositoryState = {
+  repositoryList: [],
+};
+
+function repositoryReducer(
+  state: RepositoryState = initialState,
+  action: RepositoryAction,
+) {
+  switch (action.type) {
+    case 'STARRED_REPOSITORY_SUCCESS':
+      let repoData: Array<Items> = [];
+      for (let i = 0; i < action.payload.length; i++) {
+        let repoType: string;
+        if (action.payload[i].fork === false) {
+          repoType = 'repo-forked';
+        } else {
+          repoType = 'repo';
+        }
+        let breakData: Items = {
+          id: action.payload[i].id,
+          name: action.payload[i].name,
+          description: action.payload[i].description,
+          stargazersCount: action.payload[i].stargazers_count,
+          forked: action.payload[i].forks_count,
+          language: action.payload[i].language,
+          link: action.payload[i].url,
+          repoType: repoType,
+        };
+        repoData.push(breakData);
+      }
+      return {
+        ...state,
+        repositoryList: repoData,
+      };
+    case 'ON_PAGE_MOUNT':
+      return state;
+    case 'ON_PAGE_MOUNT_ERROR':
+      return {...state, message: action.payload.message};
+    default:
+      return state;
+  }
+}
+
+export default repositoryReducer;

--- a/src/features/star/sagas/starSaga.js
+++ b/src/features/star/sagas/starSaga.js
@@ -1,0 +1,33 @@
+import {put, all, fork, takeLatest, call} from 'redux-saga/effects';
+import fetchJSON from '../../../global/helpers/fetchJSON';
+
+//watcher
+export default function* onPageInit() {
+  yield takeLatest('ON_PAGE_MOUNT', fetchDataForPage);
+}
+
+//saga
+export function* fetchDataForPage() {
+  try {
+    yield all([
+      fork(requestAndPut, [repositoryRequest], repositoryRequestActionCreator),
+    ]);
+  } catch (e) {
+    yield put({type: 'ON_PAGE_MOUNT_ERROR', payload: {message: e}});
+  }
+}
+
+//helper
+function* requestAndPut(requestParameters, actionCreator) {
+  const result = yield call(...requestParameters);
+  yield put(actionCreator(result));
+}
+
+const repositoryRequest = () => {
+  return fetchJSON('user/starred', 'GET');
+};
+
+const repositoryRequestActionCreator = (data) => ({
+  type: 'STARRED_REPOSITORY_SUCCESS',
+  payload: data,
+});

--- a/src/features/star/screens/StarDetailScreen.js
+++ b/src/features/star/screens/StarDetailScreen.js
@@ -1,0 +1,323 @@
+// @flow
+import React, {Component} from 'react';
+import {View, Text, TouchableOpacity, Image} from 'react-native';
+import {Octicons, MaterialIcons} from '@expo/vector-icons';
+import ParallaxScrollView from 'react-native-parallax-scroll-view';
+import {SafeAreaView} from 'react-navigation';
+import type {NavigationScreenProp} from 'react-navigation';
+import languageColor from '../../../global/constants/languageColor';
+import Icon from '../../../global/core-ui/Icon';
+import fetchJSON from '../../../global/helpers/fetchJSON';
+
+import ParallaxButtons from '../../../global/core-ui/ParallaxButtons';
+import DetailsGroup from '../../../global/core-ui/DetailsGroup';
+import RowWith3Column from '../../../global/core-ui/RowWith3Column';
+import Button from '../../../global/core-ui/Button';
+
+type Props = {
+  navigation: *;
+};
+
+type State = {
+  forks: number;
+  fork: boolean;
+  language: string;
+  name: string;
+  description: string;
+  watchers: number;
+  stargazersCount: number;
+  ownerProfilePicture: string;
+  ownerName: string;
+};
+
+export class RepositoryDetailScreen extends Component<Props, State> {
+  static navigationOptions = (options: *) => ({
+    headerTransparent: true,
+    headerLeft: (
+      <View style={{paddingLeft: 10}}>
+        <TouchableOpacity onPress={() => options.navigation.goBack()}>
+          <Text style={{color: 'white'}}>Back</Text>
+        </TouchableOpacity>
+      </View>
+    ),
+  });
+  state = {
+    forks: 0,
+    fork: false,
+    language: '',
+    name: '',
+    description: '',
+    watchers: 0,
+    stargazersCount: 0,
+    ownerProfilePicture: '',
+    ownerName: '',
+  };
+  async componentDidMount() {
+    let {fullName} = this.props.navigation.state.params;
+    let url = `repos/${fullName}`;
+    let repoData = await fetchJSON(url, 'GET');
+    let {
+      forks,
+      fork,
+      language,
+      name,
+      description,
+      watchers,
+      stargazers_count,
+      owner,
+    } = repoData;
+    this.setState({
+      forks,
+      fork,
+      language,
+      name,
+      description,
+      watchers,
+      stargazersCount: stargazers_count,
+      ownerProfilePicture: owner.avatar_url,
+      ownerName: owner.login,
+    });
+  }
+
+  render() {
+    let {language} = this.state;
+    let repoType = this.state.fork ? 'repo-forked' : 'repo';
+    let langColor = languageColor.hasOwnProperty(language)
+      ? languageColor[language]
+      : '#000000';
+    langColor = langColor ? langColor : '#000000';
+    let langView = () => {
+      return language ? (
+        <View style={styleParallax.containerLanguage}>
+          <Icon
+            name="circle"
+            color={langColor}
+            size={12}
+            type={'FONTAWESOME'}
+          />
+          <Text style={{fontSize: 12, color: 'white', textAlign: 'center'}}>
+            {language}
+          </Text>
+        </View>
+      ) : (
+        <View style={styleParallax.containerLanguage} />
+      );
+    };
+    return (
+      <SafeAreaView style={{flex: 1}}>
+        <ParallaxScrollView
+          styles={{height: 10000}}
+          backgroundColor="#272727"
+          contentBackgroundColor="white"
+          parallaxHeaderHeight={300}
+          stickyHeaderHeight={50}
+          contentContainerStyle={styleParallax.contentStyle}
+          renderStickyHeader={() => (
+            <View style={styleParallax.stickyHeader}>
+              <Text style={styleParallax.txtStickyHeader}>
+                {this.state.name}
+              </Text>
+            </View>
+          )}
+          renderForeground={() => (
+            <View style={styleParallax.containerForeground}>
+              {langView()}
+              <View style={styleParallax.containerProfilePicture}>
+                <Text style={{fontSize: 75}}> </Text>
+                <Octicons name={repoType} size={75} color="white" />
+              </View>
+              <View style={styleParallax.containerFullName}>
+                <Text style={styleParallax.txtFullName}>{this.state.name}</Text>
+              </View>
+              <View style={styleParallax.containerButton}>
+                <ParallaxButtons
+                  name="Stars"
+                  value={this.state.stargazersCount}
+                />
+                <ParallaxButtons name="Watchers" value={this.state.watchers} />
+                <ParallaxButtons name="Forks" value={this.state.forks} />
+              </View>
+            </View>
+          )}
+        >
+          <View style={styles.containerProfileDetails}>
+            <DetailsGroup name="Owner">
+              <RowWith3Column
+                left={
+                  this.state.ownerProfilePicture ? (
+                    <Image
+                      source={{uri: this.state.ownerProfilePicture}}
+                      alt={'profilePicture'}
+                      style={{
+                        height: 40,
+                        width: 40,
+                        borderRadius: 40,
+                        backgroundColor: 'yellow',
+                      }}
+                    />
+                  ) : null
+                }
+                content={<Text>{this.state.ownerName}</Text>}
+                right={
+                  <MaterialIcons
+                    name="keyboard-arrow-right"
+                    size={32}
+                    color="#D3D3D3"
+                  />
+                }
+                isTouchable={true}
+              />
+            </DetailsGroup>
+            <DetailsGroup name="Contributors">
+              <RowWith3Column content={<Text>No Contributors Found</Text>} />
+            </DetailsGroup>
+            <DetailsGroup name="Source">
+              <RowWith3Column
+                left={<MaterialIcons name="code" size={32} color="#D3D3D3" />}
+                content={<Text>View Code</Text>}
+                right={
+                  <MaterialIcons
+                    name="keyboard-arrow-right"
+                    size={32}
+                    color="#D3D3D3"
+                  />
+                }
+                isTouchable
+                onPress={() => {
+                  this.props.navigation.navigate('RepositoryFileListScreen', {
+                    fullName: `${this.state.ownerName}/${this.state.name}`,
+                  });
+                }}
+              />
+            </DetailsGroup>
+            <DetailsGroup
+              name="Issues"
+              right={<Button title="Add Issue" onPress={() => {}} />}
+            >
+              <RowWith3Column content={<Text> No Issues </Text>} />
+            </DetailsGroup>
+            <DetailsGroup
+              name="Pull Request"
+              right={<Button title="View All" onPress={() => {}} />}
+            >
+              <RowWith3Column content={<Text> No Pull Request </Text>} />
+            </DetailsGroup>
+          </View>
+        </ParallaxScrollView>
+      </SafeAreaView>
+    );
+  }
+}
+const styles = {
+  containerProfileDetails: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+};
+const styleParallax = {
+  contentStyle: {
+    flex: 1,
+  },
+  containerForeground: {
+    backgroundColor: '#272727',
+    height: 300,
+    flex: 1,
+    paddingTop: 40,
+    flexDirection: 'column',
+  },
+  stickyHeader: {
+    backgroundColor: '#272727',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: 50,
+  },
+  containerLanguage: {
+    flexDirection: 'row',
+    height: 25,
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+  },
+  containerProfilePicture: {
+    // flex: 1,
+    flexDirection: 'row',
+    height: 75,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  imgProfilePicture: {
+    width: 80,
+    height: 80,
+    borderRadius: 100,
+    backgroundColor: '>ow',
+  },
+  containerFullName: {
+    // flex: 1,
+    height: 30,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  containerUsername: {
+    // flex: 1,
+    height: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  containerButton: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingTop: 25,
+    paddingBottom: 25,
+    paddingLeft: 15,
+    paddingRight: 15,
+  },
+  buttonRepositories: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonStars: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonFollowers: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonFollowing: {
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  txtStickyHeader: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 20,
+  },
+  txtFullName: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 20,
+  },
+  txtUsername: {
+    color: 'white',
+    fontSize: 16,
+  },
+  txtButton: {
+    color: 'white',
+    fontSize: 14,
+  },
+  txtButtonValue: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 24,
+  },
+};
+
+export default RepositoryDetailScreen;

--- a/src/features/star/screens/StarScreen.js
+++ b/src/features/star/screens/StarScreen.js
@@ -1,0 +1,149 @@
+// @flow
+
+import React, {Component} from 'react';
+import {ScrollView, View, TouchableOpacity, Text} from 'react-native';
+import RepoComponent from '../../../components/Repo';
+import {SearchBar} from 'react-native-elements';
+import fetchJSON from '../../../global/helpers/fetchJSON';
+import Icon from '../../../global/core-ui/Icon';
+import {connect} from 'react-redux';
+
+import type {Repo, RepoFromAPI} from '../types';
+
+type Props = {
+  navigation: Object;
+  handleAction: (action: Object) => void;
+};
+type State = {
+  items: Array<Repo>;
+  search: string;
+};
+export class StarScreen extends Component<Props, State> {
+  static navigationOptions = (options: *) => ({
+    headerLeft: (
+      <View style={{paddingLeft: 10}}>
+        <TouchableOpacity
+          onPress={() => {
+            options.navigation.goBack(null);
+          }}
+        >
+          <Icon
+            name={'arrow-back'}
+            size={30}
+            color={'black'}
+            type={'MATERIAL_ICONS'}
+          />
+        </TouchableOpacity>
+      </View>
+    ),
+    headerTitle: (
+      <Text style={{fontSize: 24, fontWeight: 'bold'}}>
+        Starred Repositories
+      </Text>
+    ),
+  });
+  state = {
+    items: [],
+    search: '',
+  };
+  async componentDidMount() {
+    let url = '';
+    if (this.props.navigation.state.params) {
+      if (this.props.navigation.state.params.username != null) {
+        url = `users/${
+          this.props.navigation.state.params.username
+        }/starred?sort=created`;
+      }
+    }
+    if (url === '') {
+      url = 'user/starred?affiliation=owner&sort=created';
+    }
+    let repoList: Array<RepoFromAPI> = await fetchJSON(url, 'GET');
+    let repos = [];
+    repoList.map((repo) => {
+      let {
+        id,
+        name,
+        description,
+        forks,
+        fork,
+        full_name,
+        language,
+        stargazers_count,
+      } = repo;
+      repos.push({
+        id,
+        name,
+        description,
+        fork,
+        forks,
+        link: () => {
+          this.props.navigation.navigate('RepositoryDetailScreen', {
+            fullName: full_name,
+          });
+        },
+        language,
+        stargazersCount: stargazers_count,
+      });
+    });
+    this.props.handleAction({type: 'STAR_LIST_SUCCESS', data: repos});
+    this.setState({items: repos});
+  }
+  render() {
+    let {items = [], search} = this.state;
+    let showItems = [];
+    if (search !== '') {
+      items.forEach((item) => {
+        if (item.name.toLowerCase().includes(search.toLowerCase())) {
+          showItems.push(item);
+        }
+      });
+    } else {
+      showItems = items;
+    }
+    return (
+      <View style={{flex: 1}}>
+        <SearchBar
+          onChangeText={(text: string): void => this.setState({search: text})}
+          onClearText={() => this.setState({search: ''})}
+          value={this.state.search}
+          placeholderTextColor={'#E1E4EC'}
+          placeholder={'Type Here...'}
+          icon={{
+            type: 'material',
+            color: '#909AA3',
+            name: 'search',
+            style: {alignContent: 'center'},
+          }}
+          inputStyle={{backgroundColor: '#E1E4EC'}}
+          containerStyle={{
+            backgroundColor: 'white',
+            borderBottomWidth: 0.1,
+            borderTopWidth: 0.5,
+          }}
+        />
+        <ScrollView>
+          {showItems.map((item, key) => {
+            return (
+              <View key={key}>
+                <RepoComponent {...item} />
+              </View>
+            );
+          })}
+        </ScrollView>
+      </View>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {};
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    handleAction: (action: Object) => dispatch(action),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(StarScreen);

--- a/src/features/star/types.js
+++ b/src/features/star/types.js
@@ -1,0 +1,41 @@
+// @flow
+
+export type RepoFromAPI = {
+  description: string;
+  fork: boolean;
+  forks: number;
+  full_name: string; // Different
+  id: number;
+  language: string;
+  name: string;
+  stargazers_count: number; // Different
+};
+export type Repo = {
+  description: string;
+  fork: boolean;
+  forks: number;
+  link: Function;
+  id: number;
+  language: string;
+  name: string;
+  stargazersCount: number;
+};
+
+export type FetchFile = {
+  _links: {
+    git: string;
+    html: string;
+    self: string;
+  };
+  content: string;
+  download_url: string;
+  encoding: string;
+  git_url: string;
+  html_url: string;
+  name: string;
+  path: string;
+  sha: string;
+  size: string;
+  type: string;
+  url: string;
+};

--- a/src/global/rootReducer.js
+++ b/src/global/rootReducer.js
@@ -5,10 +5,12 @@ import notificationReducer from '../features/notification/reducers/notificationR
 import loginReducer from '../features/auth/reducers/loginReducer';
 import profileReducer from '../features/profile/reducers/profileReducer';
 import searchReducer from '../features/search/reducers/searchReducer';
+import starReducer from '../features/star/reducers/starReducer';
 
 export default combineReducers({
   loginReducer,
   searchReducer,
   notificationReducer,
   profileReducer,
+  starReducer,
 });

--- a/src/global/rootSaga.js
+++ b/src/global/rootSaga.js
@@ -2,7 +2,10 @@
 import {fork} from 'redux-saga/effects';
 import authSaga from '../features/auth/sagas';
 import profilesaga from '../features/profile/sagas/profileSaga';
+import starSaga from '../features/star/sagas/starSaga';
+
 export default function* rootSaga(): Iterable<*> {
   yield fork(authSaga);
   yield fork(profilesaga);
+  yield fork(starSaga);
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -21,6 +21,8 @@ import {
   RepositoryDetailScreen,
   RepositoryFileListScreen,
 } from './features/repository/screens/index';
+import StarScreen from './features/star/screens/StarScreen';
+import StarDetailScreen from './features/star/screens/StarDetailScreen';
 
 import SearchTab from './features/search/assets/SearchTab';
 import renderIcon from './features/search/assets/renderIcon';
@@ -62,6 +64,15 @@ let Setting = createStackNavigator({
   },
 });
 
+let Stars = createStackNavigator({
+  Stars: {
+    screen: StarScreen,
+  },
+  StarDetail: {
+    screen: StarDetailScreen,
+  },
+});
+
 let Profile = createStackNavigator(
   {
     Profile: {
@@ -76,6 +87,9 @@ let Profile = createStackNavigator(
     },
     RepositoryDetailScreen: {
       screen: RepositoryDetailScreen,
+    },
+    Stars: {
+      screen: Stars,
     },
     ...sharedScreens,
   },


### PR DESCRIPTION
1. Added Starred repository list and starred repository detail screens. These are accessible from the profile screen. Saga will be implemented after flow typing is fixed.
<img width="392" alt="screen shot 2018-08-29 at 5 03 59 pm" src="https://user-images.githubusercontent.com/6929833/44781060-99a1a680-abad-11e8-95c9-9fe79f2f7d57.png">
<img width="381" alt="screen shot 2018-08-29 at 5 03 50 pm" src="https://user-images.githubusercontent.com/6929833/44781062-99a1a680-abad-11e8-8fc4-48d4eb8f7319.png">

