### PR TITLE
Linked Followers and Following to Profile Screen

### DIFF
--- a/src/features/profile/sagas/profileSaga.js
+++ b/src/features/profile/sagas/profileSaga.js
@@ -1,56 +1,44 @@
-//@flow
-
-import {put, all, takeLatest, fork, call} from 'redux-saga/effects';
+import {put, all, takeLatest} from 'redux-saga/effects';
 import fetchJSON from '../../../global/helpers/fetchJSON';
 
 //watcher
-export default function* onPageInit(): Generator<*, *, *> {
+export default function* onPageInit() {
   yield takeLatest('ON_PAGE_MOUNT', fetchDataForPage);
 }
 
 //saga
-export function* fetchDataForPage(): Generator<*, *, *> {
+export function* fetchDataForPage(action) {
+  let userLogin = action.payload.userLogin;
+
+  let buildstring = {
+    user: '',
+    star: '',
+    orgs: '',
+  };
+
+  if (action.payload.userLogin === '') {
+    buildstring.user = 'user';
+    buildstring.star = 'user/starred';
+    buildstring.orgs = 'user/orgs';
+  } else {
+    buildstring.user = `users/${userLogin}`;
+    buildstring.star = `users/${userLogin}/starred`;
+    buildstring.orgs = `users/${userLogin}/orgs`;
+  }
+
   try {
+    let {user, star, orgs} = yield all({
+      user: fetchJSON(buildstring.user, 'GET'),
+      star: fetchJSON(buildstring.star, 'GET'),
+      orgs: fetchJSON(buildstring.orgs, 'GET'),
+    });
+
     yield all([
-      fork(requestAndPut, firstRequest, firstRequestActionCreator),
-      fork(requestAndPut, secondRequest, secondRequestActionCreator),
-      fork(requestAndPut, thirdRequest, thirdRequestActionCreator),
+      put({type: 'PROFILE_SUCCESS', payload: user}),
+      put({type: 'STAR_SUCCESS', payload: star}),
+      put({type: 'ORGANIZATION_SUCCESS', payload: orgs}),
     ]);
   } catch (e) {
     yield put({type: 'ON_PAGE_MOUNT_ERROR', payload: {message: e}});
   }
 }
-
-//helper
-function* requestAndPut(requestParameters, actionCreator) {
-  const result = yield call(requestParameters);
-  yield put(actionCreator(result));
-}
-const firstRequest = () => {
-  return fetchJSON('user', 'GET');
-};
-
-const firstRequestActionCreator = (data) => {
-  return {
-    type: 'PROFILE_SUCCESS',
-    payload: data,
-  };
-};
-
-const secondRequest = () => {
-  return fetchJSON('user/orgs', 'GET');
-};
-
-const secondRequestActionCreator = (data) => ({
-  type: 'ORGANIZATION_SUCCESS',
-  payload: data,
-});
-
-const thirdRequest = () => {
-  return fetchJSON('user/starred', 'GET');
-};
-
-const thirdRequestActionCreator = (data) => ({
-  type: 'STAR_SUCCESS',
-  payload: data,
-});

--- a/src/features/profile/sagas/profileSaga.js
+++ b/src/features/profile/sagas/profileSaga.js
@@ -15,7 +15,6 @@ export function* fetchDataForPage(action) {
     star: '',
     orgs: '',
   };
-
   if (action.payload.userLogin === '') {
     buildstring.user = 'user';
     buildstring.star = 'user/starred';

--- a/src/features/profile/screens/ProfileScreen.js
+++ b/src/features/profile/screens/ProfileScreen.js
@@ -26,22 +26,24 @@ type Props = {
 type State = {};
 
 class ProfileScreen extends Component<Props, State> {
-  // componentDidMount() {
-  // }
-
   async componentDidMount() {
     //let {userLogin = ''} = this.props.navigation.state.params;
-    // console.log(this.props.navigation.state.params, 'params');
-    // this.props.handleAction({type: 'ON_PAGE_MOUNT'});
+    //this.props.handleAction({type: 'ON_PAGE_MOUNT'});
     //Mock Data
-    let userLogin = 'sstur';
-
+    let userLogin = this.props.navigation.getParam('userLogin', '');
     this.props.handleAction({
       type: 'ON_PAGE_MOUNT',
       payload: {userLogin: userLogin},
     });
   }
 
+  async componentDidUpdate() {
+    // this.props.navigation.setParams({userLogin: ''});
+    // this.props.handleAction({
+    //   type: 'ON_PAGE_MOUNT',
+    //   payload: {userLogin: ''},
+    // });
+  }
   render() {
     let {
       userLogin,
@@ -117,17 +119,32 @@ class ProfileScreen extends Component<Props, State> {
                 <ParallaxButtons
                   name="Stars"
                   value={sumStars}
-                  onPress={() => this.props.navigation.navigate('Stars')}
+                  onPress={() =>
+                    this.props.navigation.navigate({
+                      routeName: 'Stars',
+                      key: userLogin,
+                    })
+                  }
                 />
                 <ParallaxButtons
                   name="Followers"
                   value={sumFollowers}
-                  onPress={() => this.props.navigation.navigate('Followers')}
+                  onPress={() =>
+                    this.props.navigation.navigate({
+                      routeName: 'Followers',
+                      key: userLogin,
+                    })
+                  }
                 />
                 <ParallaxButtons
                   name="Following"
                   value={sumFollowing}
-                  onPress={() => this.props.navigation.navigate('Following')}
+                  onPress={() =>
+                    this.props.navigation.navigate({
+                      routeName: 'Following',
+                      key: userLogin,
+                    })
+                  }
                 />
               </View>
             </View>

--- a/src/features/profile/screens/ProfileScreen.js
+++ b/src/features/profile/screens/ProfileScreen.js
@@ -13,11 +13,12 @@ import ParallaxButtons from '../../../global/core-ui/ParallaxButtons';
 import RowWith3Column from '../../../global/core-ui/RowWith3Column';
 import type {ProfileState} from '../reducers/profileReducer';
 
-type NavProps = {
+type NavProp = {
   userLogin: string;
 };
+
 type Props = {
-  navigation: NavigationProp<NavProps>;
+  navigation: NavigationProp<NavProp>;
   handleAction: (action: Object) => void;
   profileState: ProfileState;
 };
@@ -25,9 +26,17 @@ type Props = {
 type State = {};
 
 class ProfileScreen extends Component<Props, State> {
-  componentDidMount() {
-    console.log(this.props.navigation.state.params, 'params');
-    this.props.handleAction({type: 'ON_PAGE_MOUNT'});
+  async componentDidMount() {
+    //let {userLogin = ''} = this.props.navigation.state.params;
+    // console.log(this.props.navigation.state.params, 'params');
+    // this.props.handleAction({type: 'ON_PAGE_MOUNT'});
+    //Mock Data
+    let userLogin = 'sstur';
+
+    this.props.handleAction({
+      type: 'ON_PAGE_MOUNT',
+      payload: {userLogin: userLogin},
+    });
   }
 
   render() {
@@ -256,7 +265,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ProfileScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(ProfileScreen);

--- a/src/features/profile/screens/ProfileScreen.js
+++ b/src/features/profile/screens/ProfileScreen.js
@@ -26,6 +26,9 @@ type Props = {
 type State = {};
 
 class ProfileScreen extends Component<Props, State> {
+  // componentDidMount() {
+  // }
+
   async componentDidMount() {
     //let {userLogin = ''} = this.props.navigation.state.params;
     // console.log(this.props.navigation.state.params, 'params');


### PR DESCRIPTION
1. users listed on Followers and Following screen are now linked to profile screen. Clicking on these users would lead to their profile displayed on profile screen.
<img width="380" alt="screen shot 2018-08-31 at 4 27 38 pm" src="https://user-images.githubusercontent.com/6929833/44904951-ccc57080-ad3a-11e8-83b4-1bcaf93631f6.png">

<img width="387" alt="screen shot 2018-08-31 at 4 26 50 pm" src="https://user-images.githubusercontent.com/6929833/44904913-b6b7b000-ad3a-11e8-921a-d8dbfd3b0a53.png">

This feature is bugged. After any user(other than the currently logged in one) is displayed, profile screen cannot display currently logged in user. It is stuck on the latest displayed user.